### PR TITLE
Output ARN for new layer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ async function run() {
             })
             .promise()
 
+        core.setOutput('LayerVersionArn', response.LayerVersionArn);
         core.info(`Publish Success : ${response.LayerVersionArn}`)
     } catch (error) {
         core.setFailed(error)


### PR DESCRIPTION
When creating a new layer, its usually needed right away in another step.  This change exports the arn of the newly created layer to be used later.  